### PR TITLE
Undo plagiarism of schnorr module

### DIFF
--- a/packages/zilliqa-js-crypto/src/schnorr.ts
+++ b/packages/zilliqa-js-crypto/src/schnorr.ts
@@ -1,19 +1,32 @@
-//  Copyright (C) 2018 Zilliqa
-//
-//  This file is part of zilliqa-js
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/*!
+ * schnorr.js - schnorr signatures for bcoin
+ * Copyright (c) 2017, Christopher Jeffrey (MIT License).
+ * https://github.com/bcoin-org/bcoin
+ */
+
+/**
+ * This software is licensed under the MIT License.
+ *
+ * Copyright (c) 2017, Christopher Jeffrey (https://github.com/chjj)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 import { ec } from 'elliptic';
 import hashjs from 'hash.js';


### PR DESCRIPTION
Years ago, zilliqa-js [included][1] my [schnorr] code in its codebase. I have no issues with that as it retained the proper copyright notice and attribution.

Unfortunately, every version of zilliqa-js distributed from [c274377][2] to [ed7704d][3] (the current HEAD) is in direct violation of the [license] for my [schnorr] project.

[c274377][2] removed the copyright notice after a refactor and rename, and [ed7704d][3] illegaly relicensed my code under the GPL3.

This PR adds the proper license and attribution. As the license holder, I refuse to have it relicensed as GPL, so you'll have to figure that out if you want to put your own attribution there.

On the condition that this is merged, you have my word that I will not pursue anything legally, but I would appreciate a public apology, maybe through twitter or some other means.

[1]: https://github.com/Zilliqa/zilliqa-js/blob/d6e0c99a75b45f9256e1e96d3a1f02ecbbfbd950/lib/schnorr.js
[2]: https://github.com/Zilliqa/zilliqa-js/blob/c27437744687280477587e4a95b63701a07cee7f/packages/zilliqa-js-crypto/src/schnorr.ts
[3]: https://github.com/Zilliqa/zilliqa-js/blob/ed7704d5d15055c3e55c05786e16fc4bedc8f5e2/packages/zilliqa-js-crypto/src/schnorr.ts
[license]: https://github.com/bcoin-org/schnorr/blob/master/LICENSE
[schnorr]: https://github.com/bcoin-org/schnorr